### PR TITLE
No more boilerplate code to create a message processor.

### DIFF
--- a/src/main/java/com/clearlydecoded/messenger/AbstractMessageProcessor.java
+++ b/src/main/java/com/clearlydecoded/messenger/AbstractMessageProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package com.clearlydecoded.messenger;
+
+import java.lang.reflect.ParameterizedType;
+import java.text.MessageFormat;
+import lombok.extern.java.Log;
+
+/**
+ * {@link AbstractMessageProcessor} abstract class implements boilerplate methods of the {@link
+ * MessageProcessor} interface such that the user of this interface does not have to bother.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Log
+public abstract class AbstractMessageProcessor
+    <MessageT extends Message<MessageResponseT>, MessageResponseT extends MessageResponse>
+    implements MessageProcessor<MessageT, MessageResponseT> {
+
+  @Override
+  public String getCompatibleMessageType() {
+
+    // Retrieve concerete message class type
+    Class<MessageT> concreteMessageClass = this.getCompatibleMessageClassType();
+
+    try {
+
+      // Instantiate the concrete message class and retrieve its spring-based type identifier
+      Message<? extends MessageResponse> message = concreteMessageClass.newInstance();
+
+      return message.getType();
+
+    } catch (InstantiationException | IllegalAccessException e) {
+      String logTemplate = "Error trying to register message processor [{0}]. Did not find public"
+          + " no-argument constructor on the message class of type [{1}]. Message implementations"
+          + " must have public no-argument constructor.";
+      String logMessage = MessageFormat
+          .format(logTemplate, this.getClass(), concreteMessageClass);
+
+      // Rethrow as IllegalStateException
+      log.severe(logMessage);
+      throw new IllegalStateException(logMessage, e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Class<MessageT> getCompatibleMessageClassType() {
+
+    return (Class<MessageT>) ((ParameterizedType) getClass()
+        .getGenericSuperclass())
+        .getActualTypeArguments()[0];
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Class<MessageResponseT> getCompatibleMessageResponseClassType() {
+
+    return (Class<MessageResponseT>) ((ParameterizedType) getClass()
+        .getGenericSuperclass())
+        .getActualTypeArguments()[1];
+  }
+}

--- a/src/main/java/com/clearlydecoded/messenger/DefaultMessageProcessorRegistry.java
+++ b/src/main/java/com/clearlydecoded/messenger/DefaultMessageProcessorRegistry.java
@@ -45,7 +45,7 @@ public class DefaultMessageProcessorRegistry implements MessageProcessorRegistry
     processorMap.put(processorStringType, processor);
 
     // Log registration
-    Class<?> processedMessage = processor.getCompatibleMessage();
+    Class<?> processedMessage = processor.getCompatibleMessageClassType();
     String logTemplate = "Registered [{0}] to process messages of type [{1}] identified by [{2}]";
 
     if (log.isLoggable(Level.INFO)) {

--- a/src/main/java/com/clearlydecoded/messenger/MessageProcessor.java
+++ b/src/main/java/com/clearlydecoded/messenger/MessageProcessor.java
@@ -56,7 +56,7 @@ public interface MessageProcessor
    *
    * @return Class type of the message this processor is able to process.
    */
-  Class<MessageT> getCompatibleMessage();
+  Class<MessageT> getCompatibleMessageClassType();
 
   /**
    * Retrieves class type of the message response this processor is set to return.

--- a/src/main/java/com/clearlydecoded/messenger/discovery/MessageProcessorValidator.java
+++ b/src/main/java/com/clearlydecoded/messenger/discovery/MessageProcessorValidator.java
@@ -62,7 +62,7 @@ public class MessageProcessorValidator {
 
     // Retrieve Java class message type and string-based message type
     Class<? extends Message<? extends MessageResponse>> processorMessageClassType =
-        processor.getCompatibleMessage();
+        processor.getCompatibleMessageClassType();
     String processorMessageStringType = processor.getCompatibleMessageType();
 
     try {

--- a/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentationGenerator.java
+++ b/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentationGenerator.java
@@ -65,7 +65,7 @@ public class RestProcessorDocumentationGenerator {
     RestProcessorDocumentation documentation = new RestProcessorDocumentation();
 
     // Extract message & message response classes
-    Class<? extends Message> messageClass = processor.getCompatibleMessage();
+    Class<? extends Message> messageClass = processor.getCompatibleMessageClassType();
     Class<? extends MessageResponse> messageResponseClass = processor
         .getCompatibleMessageResponseClassType();
 

--- a/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
+++ b/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
@@ -224,7 +224,7 @@ public class SpringRestMessenger {
 
     // Retrieve message processor's message class type
     Class<MessageT> processorMessageClassType = messageProcessor
-        .getCompatibleMessage();
+        .getCompatibleMessageClassType();
 
     // Attempt to deserialize string message using message processor's message class type
     MessageT javaTypedMessage;

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/ApplicationConfig.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/ApplicationConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.noboilerplate;
+
+import com.clearlydecoded.messenger.MessageProcessorRegistry;
+import com.clearlydecoded.messenger.discovery.SpringMessageProcessorRegistryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link ApplicationConfig} class is used to setup Spring Context configuration for registry
+ * related tests.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Configuration
+@ComponentScan
+public class ApplicationConfig {
+
+  @Autowired
+  private ApplicationContext springContext;
+
+  /**
+   * Use the Spring-based message processor registry factory to create the registry with
+   * automatically discovered message processors and expose it as a Bean into the Spring Context.
+   */
+  @Bean
+  public MessageProcessorRegistry configureCommandHandlerRegistry() {
+    return SpringMessageProcessorRegistryFactory
+        .discoverMessageProcessorsAndCreateRegistry(springContext);
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessage.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessage.java
@@ -1,0 +1,21 @@
+package test.com.clearlydecoded.messenger.discovery.noboilerplate;
+
+import com.clearlydecoded.messenger.Message;
+
+/**
+ * {@link NoBoilerPlateMessage} class is a message for testing {@link
+ * com.clearlydecoded.messenger.AbstractMessageProcessor}.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+public class NoBoilerPlateMessage implements Message<NoBoilerPlateMessageResponse> {
+
+  public static final String TYPE = "NoBoilerPlateMessage";
+
+  private final String type = TYPE;
+
+  @Override
+  public String getType() {
+    return type;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessageProcessor.java
@@ -1,0 +1,23 @@
+package test.com.clearlydecoded.messenger.discovery.noboilerplate;
+
+import com.clearlydecoded.messenger.AbstractMessageProcessor;
+import org.springframework.stereotype.Service;
+
+/**
+ * {@link NoBoilerPlateMessageProcessor} is a test class for testing {@link
+ * AbstractMessageProcessor} class.
+ */
+@Service
+public class NoBoilerPlateMessageProcessor extends
+    AbstractMessageProcessor<NoBoilerPlateMessage, NoBoilerPlateMessageResponse> {
+
+  @Override
+  public String getCompatibleMessageType() {
+    return NoBoilerPlateMessage.TYPE;
+  }
+
+  @Override
+  public NoBoilerPlateMessageResponse process(NoBoilerPlateMessage message) {
+    return null;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessageResponse.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/NoBoilerPlateMessageResponse.java
@@ -1,0 +1,17 @@
+package test.com.clearlydecoded.messenger.discovery.noboilerplate;
+
+import com.clearlydecoded.messenger.MessageResponse;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * {@link NoBoilerPlateMessageResponse} class is a response message for testing {@link
+ * com.clearlydecoded.messenger.AbstractMessageProcessor}.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Data
+@NoArgsConstructor
+public class NoBoilerPlateMessageResponse implements MessageResponse {
+
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/SpringMessageProcessorRegistryNoBoilerPlateTest.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/noboilerplate/SpringMessageProcessorRegistryNoBoilerPlateTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.noboilerplate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.clearlydecoded.messenger.MessageProcessorRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * {@link SpringMessageProcessorRegistryNoBoilerPlateTest} class is used to test registration of a
+ * processor constructed using the {@link com.clearlydecoded.messenger.AbstractMessageProcessor}
+ * class.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@SpringBootTest(classes = ApplicationConfig.class)
+@RunWith(SpringRunner.class)
+public class SpringMessageProcessorRegistryNoBoilerPlateTest {
+
+  @Autowired
+  private ApplicationContext springContext;
+
+  @Autowired
+  private MessageProcessorRegistry messageProcessorRegistry;
+
+  @Test
+  public void testEverythingIsWiredCorrectly() {
+    assertNotNull("Non-null Spring Context exists and is wired correctly.", springContext);
+  }
+
+  @Test
+  public void testSuccessfulProcessorRegistration() {
+    assertNotNull("Message processor registry is not null.", messageProcessorRegistry);
+    assertEquals("1 message processors should have been automatically discovered and registered.",
+        1, messageProcessorRegistry.getProcessors().size());
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message1Handler.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message1Handler.java
@@ -31,7 +31,7 @@ public class Message1Handler implements MessageProcessor<Message1, Message1Respo
   }
 
   @Override
-  public Class<Message1> getCompatibleMessage() {
+  public Class<Message1> getCompatibleMessageClassType() {
     return Message1.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message2Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message2Processor.java
@@ -31,7 +31,7 @@ public class Message2Processor implements MessageProcessor<Message2, Message2Res
   }
 
   @Override
-  public Class<Message2> getCompatibleMessage() {
+  public Class<Message2> getCompatibleMessageClassType() {
     return Message2.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message3Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/Message3Processor.java
@@ -31,7 +31,7 @@ public class Message3Processor implements MessageProcessor<Message3, Message3Res
   }
 
   @Override
-  public Class<Message3> getCompatibleMessage() {
+  public Class<Message3> getCompatibleMessageClassType() {
     return Message3.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/WontBeDiscoveredProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/registry/WontBeDiscoveredProcessor.java
@@ -29,7 +29,7 @@ public class WontBeDiscoveredProcessor implements MessageProcessor<Message2, Mes
   }
 
   @Override
-  public Class<Message2> getCompatibleMessage() {
+  public Class<Message2> getCompatibleMessageClassType() {
     return null;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/BadMockMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/BadMockMessageProcessor.java
@@ -29,7 +29,7 @@ public class BadMockMessageProcessor implements
   }
 
   @Override
-  public Class<BadMockMessage> getCompatibleMessage() {
+  public Class<BadMockMessage> getCompatibleMessageClassType() {
     return BadMockMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageProcessor.java
@@ -30,7 +30,7 @@ public class MockMessageProcessor implements MessageProcessor<MockMessage, MockM
   }
 
   @Override
-  public Class<MockMessage> getCompatibleMessage() {
+  public Class<MockMessage> getCompatibleMessageClassType() {
     return MockMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithNoDefaultConstructorProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithNoDefaultConstructorProcessor.java
@@ -30,7 +30,7 @@ public class MockMessageWithNoDefaultConstructorProcessor implements
   }
 
   @Override
-  public Class<MockMessageWithNoDefaultConstructor> getCompatibleMessage() {
+  public Class<MockMessageWithNoDefaultConstructor> getCompatibleMessageClassType() {
     return MockMessageWithNoDefaultConstructor.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithNoPublicConstructorProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithNoPublicConstructorProcessor.java
@@ -30,7 +30,7 @@ public class MockMessageWithNoPublicConstructorProcessor implements
   }
 
   @Override
-  public Class<MockMessageWithNoPublicConstructor> getCompatibleMessage() {
+  public Class<MockMessageWithNoPublicConstructor> getCompatibleMessageClassType() {
     return MockMessageWithNoPublicConstructor.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithResponseWithNoDefaultConstructorProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/validator/MockMessageWithResponseWithNoDefaultConstructorProcessor.java
@@ -24,7 +24,7 @@ public class MockMessageWithResponseWithNoDefaultConstructorProcessor implements
   }
 
   @Override
-  public Class<MockMessageWithResponseWithNoDefaultConstructor> getCompatibleMessage() {
+  public Class<MockMessageWithResponseWithNoDefaultConstructor> getCompatibleMessageClassType() {
     return MockMessageWithResponseWithNoDefaultConstructor.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/documentation/EmployeeMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/documentation/EmployeeMessageProcessor.java
@@ -32,7 +32,7 @@ public class EmployeeMessageProcessor implements
   }
 
   @Override
-  public Class<EmployeeMessage> getCompatibleMessage() {
+  public Class<EmployeeMessage> getCompatibleMessageClassType() {
     return EmployeeMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/documentation/EnumMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/documentation/EnumMessageProcessor.java
@@ -30,7 +30,7 @@ public class EnumMessageProcessor implements MessageProcessor<EnumMessage, EnumM
   }
 
   @Override
-  public Class<EnumMessage> getCompatibleMessage() {
+  public Class<EnumMessage> getCompatibleMessageClassType() {
     return EnumMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/documentation/GetPersonMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/documentation/GetPersonMessageProcessor.java
@@ -29,7 +29,7 @@ public class GetPersonMessageProcessor implements
   }
 
   @Override
-  public Class<GetPersonMessage> getCompatibleMessage() {
+  public Class<GetPersonMessage> getCompatibleMessageClassType() {
     return GetPersonMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/documentation/PersonMessageProcessor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/documentation/PersonMessageProcessor.java
@@ -29,7 +29,7 @@ public class PersonMessageProcessor implements
   }
 
   @Override
-  public Class<PersonMessage> getCompatibleMessage() {
+  public Class<PersonMessage> getCompatibleMessageClassType() {
     return PersonMessage.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/rest/Message4Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/rest/Message4Processor.java
@@ -30,7 +30,7 @@ public class Message4Processor implements MessageProcessor<Message4, Message4Res
   }
 
   @Override
-  public Class<Message4> getCompatibleMessage() {
+  public Class<Message4> getCompatibleMessageClassType() {
     return Message4.class;
   }
 

--- a/src/test/java/test/com/clearlydecoded/messenger/rest/Message5Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/rest/Message5Processor.java
@@ -38,7 +38,7 @@ public class Message5Processor implements MessageProcessor<Message5, Message5Res
   }
 
   @Override
-  public Class<Message5> getCompatibleMessage() {
+  public Class<Message5> getCompatibleMessageClassType() {
     return Message5.class;
   }
 


### PR DESCRIPTION
* User can now simply extend the AbstractMessageProcessor class and not have to implement *any* of the boilerplate code.
  * String type identifier will automatically pick up the message type string identifier.
* Methods in the interface for getting class names have been made consistent.

Closes #18.