### PR TITLE
Does't allow same message type ID for more than 1 processor

### DIFF
--- a/src/main/java/com/clearlydecoded/messenger/DefaultMessageProcessorRegistry.java
+++ b/src/main/java/com/clearlydecoded/messenger/DefaultMessageProcessorRegistry.java
@@ -40,6 +40,9 @@ public class DefaultMessageProcessorRegistry implements MessageProcessorRegistry
     // Verify string and Java-based types are compatible in the message processor
     validateMessageProcessor(processor);
 
+    // Verify no processor for the same string-based type ID is already registered
+    validateNoDuplicateTypeIdProcessor(processor);
+
     // Place message processor into map, keyed by string-based message type identifier
     String processorStringType = processor.getCompatibleMessageType();
     processorMap.put(processorStringType, processor);
@@ -101,5 +104,36 @@ public class DefaultMessageProcessorRegistry implements MessageProcessorRegistry
   public List<MessageProcessor<? extends Message<? extends MessageResponse>,
       ? extends MessageResponse>> getProcessors() {
     return new ArrayList<>(processorMap.values());
+  }
+
+  /**
+   * Validates that the <code>processor</code> about to be added has a unique string-based type ID.
+   * If a processor with the same string-based type ID already exists in the map of processors,
+   * throw {@link IllegalStateException}.
+   *
+   * @param processor Processor to validate.
+   * @throws IllegalStateException If a processor with the same string-based type ID already exists
+   * in the map of processors
+   */
+  private void validateNoDuplicateTypeIdProcessor(
+      MessageProcessor<? extends Message<? extends MessageResponse>,
+          ? extends MessageResponse> processor) throws IllegalStateException {
+
+    // Retrieve possibly existing processor
+    MessageProcessor<? extends Message<? extends MessageResponse>, ? extends MessageResponse>
+        existingProcessor = getProcessorFor(processor.getCompatibleMessageType());
+
+    // If processor for that type already exists, throw exception
+    if (existingProcessor != null) {
+      String logMessage = "Unable to register [{0}] to process messages of type [{1}] identified"
+          + " by [{2}]. Another message processor [{3}] already identifies itself as the processor"
+          + " of the same message type with string identifier [{4}].";
+      String message = MessageFormat.format(logMessage, processor.getClass().getName(),
+          processor.getCompatibleMessageClassType().getName(),
+          processor.getCompatibleMessageType(), existingProcessor.getClass().getName(),
+          existingProcessor.getCompatibleMessageType());
+
+      throw new IllegalStateException(message);
+    }
   }
 }

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage1.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage1.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.Message;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Class for testing multiple messages with the same type id. Message2 class is declared with the
+ * same type ID.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Data
+@AllArgsConstructor
+public class MyMessage1 implements Message<MyResponse> {
+
+  public static final String TYPE = "MyMessage";
+
+  private final String type = TYPE;
+
+  @Override
+  public String getType() {
+    return type;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage1Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage1Processor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.AbstractMessageProcessor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Class for testing multiple messages with the same type id.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Service
+public class MyMessage1Processor extends AbstractMessageProcessor<MyMessage1, MyResponse> {
+
+  @Override
+  public MyResponse process(MyMessage1 message) {
+    return null;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage2.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage2.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.Message;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Class for testing multiple messages with the same type id. Message1 class is declared with the
+ * same type ID.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Data
+@AllArgsConstructor
+public class MyMessage2 implements Message<MyResponse> {
+
+  public static final String TYPE = "MyMessage";
+
+  private final String type = TYPE;
+
+  @Override
+  public String getType() {
+    return type;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage2Processor.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyMessage2Processor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.AbstractMessageProcessor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Class for testing multiple messages with the same type id.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Service
+public class MyMessage2Processor extends AbstractMessageProcessor<MyMessage2, MyResponse> {
+
+  @Override
+  public MyResponse process(MyMessage2 message) {
+    return null;
+  }
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyResponse.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/MyResponse.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.MessageResponse;
+import lombok.Data;
+
+/**
+ * Class for testing multiple messages with the same type id.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@Data
+public class MyResponse implements MessageResponse {
+
+}

--- a/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/SpringMessageProcessorRegistrySameMessageTypeIdTest.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/discovery/samemessagetype/SpringMessageProcessorRegistrySameMessageTypeIdTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Yaakov Chaikin (yaakov@ClearlyDecoded.com). Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. Unless required
+ * by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+package test.com.clearlydecoded.messenger.discovery.samemessagetype;
+
+import com.clearlydecoded.messenger.DefaultMessageProcessorRegistry;
+import com.clearlydecoded.messenger.MessageProcessor;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * {@link SpringMessageProcessorRegistrySameMessageTypeIdTest} class is used to test registration of
+ * a processors which process messages with the same string-based type ID.
+ *
+ * @author Yaakov Chaikin (yaakov@ClearlyDecoded.com)
+ */
+@SuppressWarnings("unchecked")
+public class SpringMessageProcessorRegistrySameMessageTypeIdTest {
+
+  @Test(expected = IllegalStateException.class)
+  public void testSuccessfulProcessorRegistration() {
+
+    DefaultMessageProcessorRegistry registry = new DefaultMessageProcessorRegistry();
+
+    MyMessage1Processor processor1 = new MyMessage1Processor();
+    MyMessage2Processor processor2 = new MyMessage2Processor();
+    List processors = new ArrayList<MessageProcessor>();
+    processors.add(processor1);
+    processors.add(processor2);
+
+    registry.addProcessors(processors);
+  }
+}


### PR DESCRIPTION
* Checks when registering processors that no other processors in the system are already registered with the same string-based type ID.
* If it finds another one already registered, throws IllegalStateException.

Closes #20.