### PR TITLE
Converted to property-based version for Spring Boot.

### DIFF
--- a/checkup.sh
+++ b/checkup.sh
@@ -1,0 +1,7 @@
+echo
+echo "************** BUILDING FOR LATEST SPRING BOOT 2.x ************** "
+mvn clean install
+echo
+echo
+echo "************** BUILDING FOR SPRING BOOT 1.x ************** "
+mvn clean install -Dspring-boot.version=1.5.8.RELEASE

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.3.RELEASE</version>
-    <relativePath/>
-  </parent>
-
   <groupId>com.clearlydecoded</groupId>
   <artifactId>rest-messenger</artifactId>
   <packaging>jar</packaging>
@@ -45,8 +38,24 @@
   </scm>
 
   <properties>
-    <java.version>1.8</java.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring-boot.version>2.0.3.RELEASE</spring-boot.version>
   </properties>
+
+  <!-- Alternative to having spring boot as parent, but still manage dependencies. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
* Spring Boot still manages dependencies
* checkup script to run clean test/install on both 1.x and 2.x versions.

Closes #29.