### PR TITLE
Endpoint to return JSON-based docs for processor messages in system

### DIFF
--- a/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentation.java
+++ b/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentation.java
@@ -41,9 +41,19 @@ public class RestProcessorDocumentation {
   private final String messageResponseId = UUID.randomUUID().toString();
 
   /**
+   * String-based type ID of this processor.
+   */
+  private String compatibleMessageType;
+
+  /**
    * Single word concrete message class name.
    */
   private String messageShortClassName;
+
+  /**
+   * Fully qualified concrete message class name.
+   */
+  private String messageFullClassName;
 
   /**
    * Formatted JSON string representing the model of the message.
@@ -54,6 +64,11 @@ public class RestProcessorDocumentation {
    * Single word concrete message response class name.
    */
   private String messageResponseShortClassName;
+
+  /**
+   * Fully qualified concrete message response class name.
+   */
+  private String messageResponseFullClassName;
 
   /**
    * Formatted JSON string representing the model of the message response.

--- a/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentationGenerator.java
+++ b/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentationGenerator.java
@@ -54,20 +54,24 @@ public class RestProcessorDocumentationGenerator {
       throws Exception {
     RestProcessorDocumentation documentation = new RestProcessorDocumentation();
 
-    // Extract message & message response classes
+    // Extract message & message response classes and string-based type ID
     Class<? extends Message> messageClass = processor.getCompatibleMessageClassType();
     Class<? extends MessageResponse> messageResponseClass = processor
         .getCompatibleMessageResponseClassType();
+    String compatibleMessageType = processor.getCompatibleMessageType();
 
     // Generate documentation for message and message response
     String messageDocs = generateMessageDocumentation(messageClass);
     String messageResponseDocs = generateMessageResponseDocumentation(messageResponseClass);
 
     // Set up the message processor documentation object
+    documentation.setCompatibleMessageType(compatibleMessageType);
     documentation.setMessageModel(messageDocs);
     documentation.setMessageShortClassName(messageClass.getSimpleName());
+    documentation.setMessageFullClassName(messageClass.getName());
     documentation.setMessageResponseModel(messageResponseDocs);
     documentation.setMessageResponseShortClassName(messageResponseClass.getSimpleName());
+    documentation.setMessageResponseFullClassName(messageResponseClass.getName());
 
     return documentation;
   }

--- a/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
+++ b/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
@@ -173,7 +173,7 @@ public class SpringRestMessenger {
     requestMappingHandlerMapping.registerMapping(messageProcessingRequestMappingInfo, this,
         SpringRestMessenger.class.getDeclaredMethod("process", String.class));
 
-    // Wire up request mapping for output of processor docs
+    // Wire up request mapping for output of processor docs through an HTML page
     RequestMappingInfo getProcessorDocsRequestMappingInfo = RequestMappingInfo
         .paths(endpointUri)
         .methods(RequestMethod.GET)
@@ -181,6 +181,16 @@ public class SpringRestMessenger {
         .build();
     requestMappingHandlerMapping.registerMapping(getProcessorDocsRequestMappingInfo, this,
         SpringRestMessenger.class.getDeclaredMethod("getProcessorDocs", Model.class));
+
+    // Wire up request mapping for output of processor docs through an HTML page
+    RequestMappingInfo getJsonProcessorDocsRequestMappingInfo = RequestMappingInfo
+        .paths(endpointUri)
+        .methods(RequestMethod.GET)
+        .consumes(MediaType.APPLICATION_JSON_VALUE)
+        .produces(MediaType.APPLICATION_JSON_VALUE)
+        .build();
+    requestMappingHandlerMapping.registerMapping(getJsonProcessorDocsRequestMappingInfo, this,
+        SpringRestMessenger.class.getDeclaredMethod("getJsonProcessorDocs"));
   }
 
   /**
@@ -219,6 +229,34 @@ public class SpringRestMessenger {
     log.fine("Full message response string to be sent: " + response);
 
     return response;
+  }
+
+  /**
+   * Directs the request to the HTML page that displays all the documentation for the system
+   * discovered message processors.
+   *
+   * @param model Shared model with the view.
+   * @return ID of the page to serve to the client.
+   */
+  private String getProcessorDocs(Model model) {
+
+    model.addAttribute("docs", processorDocs);
+    model.addAttribute("endpointUri", endpointUri);
+    model.addAttribute("servletContextPath", servletContextPath);
+
+    String appName = springApplicationName.trim();
+    model.addAttribute("appName", appName.equals("") ? "unspecified" : appName);
+
+    return "SpringRestProcessorDocumentation";
+  }
+
+  /**
+   * @return List of {@link RestProcessorDocumentation}s as a REST endpoint, i.e., returns docs as
+   * JSON.
+   */
+  @ResponseBody
+  private List<RestProcessorDocumentation> getJsonProcessorDocs() {
+    return processorDocs;
   }
 
   /**
@@ -272,25 +310,6 @@ public class SpringRestMessenger {
       log.severe(logMessage);
       throw new IllegalArgumentException(logMessage, e);
     }
-  }
-
-  /**
-   * Directs the request to the HTML page that displays all the documentation for the system
-   * discovered message processors.
-   *
-   * @param model Shared model with the view.
-   * @return ID of the page to serve to the client.
-   */
-  private String getProcessorDocs(Model model) {
-
-    model.addAttribute("docs", processorDocs);
-    model.addAttribute("endpointUri", endpointUri);
-    model.addAttribute("servletContextPath", servletContextPath);
-
-    String appName = springApplicationName.trim();
-    model.addAttribute("appName", appName.equals("") ? "unspecified" : appName);
-
-    return "SpringRestProcessorDocumentation";
   }
 
   /**

--- a/src/test/java/test/com/clearlydecoded/messenger/rest/basic/SpringRestMessengerTest.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/rest/basic/SpringRestMessengerTest.java
@@ -104,4 +104,20 @@ public class SpringRestMessengerTest {
     assertTrue("Response should at least contain snippet of HTML page.",
         stringResult.contains("Spring REST Messenger Docs"));
   }
+
+  @Test
+  public void testGetAvailableMessagesJsonDocs() throws Exception {
+    MvcResult result = mvc.perform(get("/process").contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8"))
+        .andReturn();
+
+    String stringResult = result.getResponse().getContentAsString();
+    assertTrue("Response should contain correct messageShortClassName.",
+        stringResult.contains("\"messageShortClassName\":\"Message5\""));
+    assertTrue("Response should contain correct compatibleMessageType.",
+        stringResult.contains("\"compatibleMessageType\":\"Message-5\""));
+
+    System.out.println(stringResult);
+  }
 }


### PR DESCRIPTION
* Same endpoint that produces POST, GET for HTML page, now produces GET for JSON as long as request header of application/json is sent along with the request.
* Enhanced documentation object with explicit message type property and fully qualified class names that implement the message and message response classes.
* Tests written to verify.

Closes #34