### PR TITLE
Browser accessible JSON-based docs for processors in system.

### DIFF
--- a/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
+++ b/src/main/java/com/clearlydecoded/messenger/rest/SpringRestMessenger.java
@@ -182,7 +182,7 @@ public class SpringRestMessenger {
     requestMappingHandlerMapping.registerMapping(getProcessorDocsRequestMappingInfo, this,
         SpringRestMessenger.class.getDeclaredMethod("getProcessorDocs", Model.class));
 
-    // Wire up request mapping for output of processor docs through an HTML page
+    // Wire up request mapping for output of processor docs through REST endpoint
     RequestMappingInfo getJsonProcessorDocsRequestMappingInfo = RequestMappingInfo
         .paths(endpointUri)
         .methods(RequestMethod.GET)
@@ -191,6 +191,16 @@ public class SpringRestMessenger {
         .build();
     requestMappingHandlerMapping.registerMapping(getJsonProcessorDocsRequestMappingInfo, this,
         SpringRestMessenger.class.getDeclaredMethod("getJsonProcessorDocs"));
+
+    // Wire up request mapping for output of processor docs through REST endpoint
+    // Should be able to request directly in browser
+    RequestMappingInfo getBrowserJsonProcessorDocsRequestMappingInfo = RequestMappingInfo
+        .paths(endpointUri + ".json")
+        .methods(RequestMethod.GET)
+        .produces(MediaType.APPLICATION_JSON_VALUE)
+        .build();
+    requestMappingHandlerMapping.registerMapping(getBrowserJsonProcessorDocsRequestMappingInfo,
+        this, SpringRestMessenger.class.getDeclaredMethod("getJsonProcessorDocs"));
   }
 
   /**


### PR DESCRIPTION
* Now, issuing a browser request to endpoint.json (e.g., /process.json) will return the JSON docs for the message processors.

Closes #37