### PR TITLE
Programmatic JSON Schema (v3) exposed through REST endpoint.

### DIFF
--- a/checkup.sh
+++ b/checkup.sh
@@ -1,7 +1,8 @@
 echo
-echo "************** BUILDING FOR LATEST SPRING BOOT 2.x ************** "
-mvn clean install
-echo
-echo
 echo "************** BUILDING FOR SPRING BOOT 1.x ************** "
 mvn clean install -Dspring-boot.version=1.5.8.RELEASE
+echo
+echo
+echo "************** BUILDING FOR LATEST SPRING BOOT 2.x ************** "
+mvn clean install
+

--- a/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentation.java
+++ b/src/main/java/com/clearlydecoded/messenger/documentation/RestProcessorDocumentation.java
@@ -9,6 +9,7 @@
 package com.clearlydecoded.messenger.documentation;
 
 import com.clearlydecoded.messenger.MessageProcessor;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -51,19 +52,14 @@ public class RestProcessorDocumentation {
   private String messageShortClassName;
 
   /**
-   * Fully qualified concrete message class name.
-   */
-  private String messageFullClassName;
-
-  /**
-   * Formatted JSON string representing the model of the message.
-   */
-  private String messageModel;
-
-  /**
    * Single word concrete message response class name.
    */
   private String messageResponseShortClassName;
+
+  /**
+   * Fully qualified concrete message class name.
+   */
+  private String messageFullClassName;
 
   /**
    * Fully qualified concrete message response class name.
@@ -71,7 +67,22 @@ public class RestProcessorDocumentation {
   private String messageResponseFullClassName;
 
   /**
+   * Formatted JSON string representing the model of the message.
+   */
+  private String messageModel;
+
+  /**
    * Formatted JSON string representing the model of the message response.
    */
   private String messageResponseModel;
+
+  /**
+   * JSON schema representation of the message type.
+   */
+  private JsonSchema messageSchema;
+
+  /**
+   * JSON schema representation of the message response type.
+   */
+  private JsonSchema messageResponseSchema;
 }

--- a/src/test/java/test/com/clearlydecoded/messenger/rest/basic/SpringRestMessengerTest.java
+++ b/src/test/java/test/com/clearlydecoded/messenger/rest/basic/SpringRestMessengerTest.java
@@ -117,7 +117,10 @@ public class SpringRestMessengerTest {
         stringResult.contains("\"messageShortClassName\":\"Message5\""));
     assertTrue("Response should contain correct compatibleMessageType.",
         stringResult.contains("\"compatibleMessageType\":\"Message-5\""));
-
-    System.out.println(stringResult);
+    assertTrue("Response should contain correct schema id for message",
+        stringResult.contains("\"messageSchema\":{\"type\":\"object\",\"id\":\"urn:jsonschema"));
+    assertTrue("Response should contain corect properties schema for message", stringResult
+        .contains(
+            "\"properties\":{\"type\":{\"type\":\"string\"},\"greeting\":{\"type\":\"string\"}}}}"));
   }
 }


### PR DESCRIPTION
* Now, issuing a browser request to endpoint.json (e.g., /process.json) will return the JSON docs along with fully compliant JSON Schmea v3 as a valid JSON object as a representation of the message and message response.
* Rearranged when `checkup.sh` executes spring boot 1.x version so the last version executed is the latest one. This allows the local .m2 directory to contain the version of the framework that is compatible with spring boot 2.0 which is what the demo app requires.

Closes #39